### PR TITLE
Replace of the Boolean type for Bool added

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ class SwiftDecodable {
 				return ["Int", null];
 			}
 		} else if (typeof value === "boolean") {
-			return ["Boolean", null];
+			return ["Bool", null];
 		} else if (typeof value === "object") {
 			if (Array.isArray(value)) {
 				let [type, struct] = this.getType(property, value[0]);


### PR DESCRIPTION
## Context
At the moment of creating the swift structure, if we detect a `Boolean` value, we have been adding a `Boolean` type in the structure, but the correct type is `Bool`.

## Changes
- `["Boolean", null];` in line 72 replaced for `return ["Bool", null];`